### PR TITLE
Use source generation instead compilation

### DIFF
--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -25,6 +25,7 @@ object SbtFrege extends Plugin {
 
     val fregeArgs = Seq(
       fregeCompiler,
+      "-j",
       "-fp", cps,
       "-d", fregeTarget.getPath
     ) ++ fregeSrcs
@@ -40,14 +41,14 @@ object SbtFrege extends Plugin {
   val fregeSettings = Seq(
     fregeOptions := Seq("-Xss1m"),
     fregeSource := (sourceDirectory in Compile).value / "frege",
-    fregeTarget := baseDirectory.value / "target" / "frege" / "classes",
-    (compile in Compile) := {
+    fregeTarget := baseDirectory.value / "target" / "frege",
+    sourceGenerators in Compile += Def.task {
       fregec((managedClasspath in Compile).value,
              (fregeSource in Compile).value,
              (fregeTarget in Compile).value,
              (fregeCompiler in Compile).value)
-      (compile in Compile).value
-    },
+      (fregeTarget.value ** "*.java").get
+    }.taskValue,
     fregeCompiler := "frege.compiler.Main",
     watchSources := {
       (watchSources in Compile).value ++

--- a/src/sbt-test/sbt-frege/mixed/build.sbt
+++ b/src/sbt-test/sbt-frege/mixed/build.sbt
@@ -1,0 +1,4 @@
+SbtFrege.fregeSettings
+ 
+libraryDependencies += "frege" % "fregec" % "3.22.524" from
+  "https://github.com/Frege/frege/releases/download/3.22.324/frege3.22.524-gcc99d7e.jar"

--- a/src/sbt-test/sbt-frege/mixed/project/plugins.sbt
+++ b/src/sbt-test/sbt-frege/mixed/project/plugins.sbt
@@ -1,0 +1,8 @@
+Option(System.getProperty("plugin.version")) match {
+  case None =>
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Please specify this property using the SBT flag -D.""".stripMargin)
+  case Some(pluginVersion) =>
+    addSbtPlugin("com.earldouglas" % "sbt-frege" % pluginVersion)
+}

--- a/src/sbt-test/sbt-frege/mixed/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
+++ b/src/sbt-test/sbt-frege/mixed/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
@@ -1,0 +1,4 @@
+package com.earldouglas.helloworld.HelloWorld where
+
+main :: [String] -> IO ()
+main _ = print "Hello, world!"

--- a/src/sbt-test/sbt-frege/mixed/src/main/java/com/earldouglas/helloworld/HelloFrege.java
+++ b/src/sbt-test/sbt-frege/mixed/src/main/java/com/earldouglas/helloworld/HelloFrege.java
@@ -1,0 +1,7 @@
+package com.earldouglas.helloworld;
+
+public class HelloFrege {
+  public static void main(String[] args) {
+    HelloWorld.main(args); // Will not compile unless Frege code is compiled
+  }
+}

--- a/src/sbt-test/sbt-frege/mixed/test
+++ b/src/sbt-test/sbt-frege/mixed/test
@@ -1,6 +1,8 @@
 # check if the file gets created
 $ absent target/frege/com/earldouglas/helloworld/HelloWorld.java
 $ absent target/scala-2.10/classes/com/earldouglas/helloworld/HelloWorld.class
+$ absent target/scala-2.10/classes/com/earldouglas/helloworld/HelloFrege.class
 > compile
 $ exists target/frege/com/earldouglas/helloworld/HelloWorld.java
 $ exists target/scala-2.10/classes/com/earldouglas/helloworld/HelloWorld.class
+$ exists target/scala-2.10/classes/com/earldouglas/helloworld/HelloFrege.class


### PR DESCRIPTION
This uses `sourceGenerators` instead of overriding `compile`.  The
result is *.java* files produced by fregec, that are subsequently
compiled via sbt into the standard target directory.

Fixes #7
Fixes #2