### PR TITLE
frege dependency for sbt-plugin itself is needed in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ addSbtPlugin("com.earldouglas" % "sbt-frege" % "0.3.0")
 
 Enable the Frege sbt plugin, and include the Frege library:
 
-*build.sbt:*
+both *project/project/build.sbt* and *build.sbt:*
 
 ```scala
 libraryDependencies += "frege" % "fregec" % "3.22.524" from


### PR DESCRIPTION
This addresses #18. If you don't build the plugin on your machine but add it solely as a dependency you don't have frege in your local ivy cache so it can't be resolved.