### PR TITLE
Add Frege REPL integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Features
 
-* Compile Frege code in *src/main/frege/*
-* Call Frege code from Java/Scala/etc. code
-* Launch the [Frege REPL][1] with your project's classes
+* Compile Frege code from your project's *src/main/frege/* directory
+* Call Frege code from your project's Java/Scala/etc. code
+* Launch the [Frege REPL][1] with your project's classes and libraries
 
 ## Requirements
 
@@ -53,15 +53,23 @@ Hello, world!
 
 ## Configuration
 
-* `fregeOptions`: Extra options for fregec (`Seq[String]`)
-* `fregeSource`: Frege source directory (default *src/main/frege/*)
-  (`File`)
-* `fregeTarget`: Frege target directory (default *target/frege/*)
-  (`File`)
-* `fregeCompiler`: Full name of the Frege compiler (default
-  *frege.compiler.Main*) (`String`)
-* `fregeLibrary`: Frege library (fregec.jar) to use (default *Frege
-  3.23.401*) (`ModuleID`)
+### Frege compiler
 
+* `fregeOptions` - Extra options for fregec: `Seq[String]`
+* `fregeSource` - Frege source directory (default *src/main/frege/*):
+  `File`
+* `fregeTarget` - Frege target directory (default *target/frege/*):
+  `File`
+* `fregeCompiler` - Full name of the Frege compiler (default
+  *frege.compiler.Main*): `String`
+* `fregeLibrary` - Frege library (fregec.jar) to use (default *Frege
+  3.23.288*), `ModuleID`
+
+### Frege REPL
+
+* `fregeReplVersion` - The version of [frege-repl][1] to use (default
+  1.3): `String`
+* `fregeReplMainClass` - The Frege REPL main class (default
+  `frege.repl.FregeRepl`): `String`
 
 [1]: https://github.com/Frege/frege-repl

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the Frege sbt plugin to your project:
 *project/plugins.sbt:*
 
 ```scala
-addSbtPlugin("com.earldouglas" % "sbt-frege" % "1.1.0")
+addSbtPlugin("com.earldouglas" % "sbt-frege" % "1.1.1")
 ```
 
 Write some Frege code:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Features
+
+* Compile Frege code in *src/main/frege/*
+* Call Frege code from Java/Scala/etc. code
+* Launch the [Frege REPL][1] with your project's classes
+
 ## Requirements
 
 * sbt 0.13.6+
@@ -32,6 +38,19 @@ $ sbt
 Hello, world!
 ```
 
+Try it from the Frege REPL:
+
+```
+$ sbt
+> fregeRepl
+
+frege> import com.earldouglas.helloworld.HelloWorld (main)
+
+frege> main []
+Hello, world!
+()
+```
+
 ## Configuration
 
 * `fregeOptions`: Extra options for fregec (`Seq[String]`)
@@ -44,7 +63,5 @@ Hello, world!
 * `fregeLibrary`: Frege library (fregec.jar) to use (default *Frege
   3.23.401*) (`ModuleID`)
 
-## Features
 
-* Compile Frege code in *src/main/frege/*
-* Call Frege code from Java/Scala/etc. code
+[1]: https://github.com/Frege/frege-repl

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Try it from the Frege REPL:
 $ sbt
 > fregeRepl
 
-frege> import com.earldouglas.helloworld.HelloWorld (main)
+frege> import example.HelloWorld (main)
 
 frege> main []
 Hello, world!

--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -1,18 +1,14 @@
 import sbt._
-import Keys._
+import sbt.Keys._
 
-object SbtFrege extends AutoPlugin {
+object SbtFregec extends AutoPlugin {
 
   object autoImport {
-    lazy val fregeOptions       = taskKey[Seq[String]]("Extra options for fregec")
-    lazy val fregeSource        = settingKey[File]("Frege source directory")
-    lazy val fregeTarget        = settingKey[File]("Frege target directory")
-    lazy val fregeCompiler      = settingKey[String]("Full name of the Frege compiler")
-    lazy val fregeLibrary       = settingKey[ModuleID]("Frege library (fregec.jar)")
-    lazy val fregeReplVersion   = settingKey[String]("Frege REPL version")
-    lazy val fregeRepl          = inputKey[Unit]("Run the Frege REPL")
-    lazy val fregeReplMainClass = settingKey[String]("Frege REPL main class")
-    lazy val fregeReplConfig    = config("frege-repl").hide
+    lazy val fregeOptions  = taskKey[Seq[String]]("Extra options for fregec")
+    lazy val fregeSource   = settingKey[File]("Frege source directory")
+    lazy val fregeTarget   = settingKey[File]("Frege target directory")
+    lazy val fregeCompiler = settingKey[String]("Full name of the Frege compiler")
+    lazy val fregeLibrary  = settingKey[ModuleID]("Frege library (fregec.jar)")
   }
 
   import autoImport._
@@ -20,7 +16,6 @@ object SbtFrege extends AutoPlugin {
 
   override def trigger = allRequirements
   override def requires = plugins.JvmPlugin
-  override val projectConfigurations = Seq(fregeReplConfig)
 
   def fregec(cp: Seq[sbt.Attributed[File]], fregeSource: File, fregeTarget: File,
              fregeCompiler: String, fregeOptions: Seq[String])
@@ -71,7 +66,27 @@ object SbtFrege extends AutoPlugin {
       ((sourceDirectory in Compile).value / "frege" ** "*").get
     },
     fregeLibrary := "org.frege-lang" % "frege" % "3.23.288-gaa3af0c",
-    libraryDependencies += fregeLibrary.value,
+    libraryDependencies += fregeLibrary.value
+  )
+
+}
+
+object SbtFregeRepl extends AutoPlugin {
+
+  object autoImport {
+    lazy val fregeReplConfig    = config("fregeReplConfig").hide
+    lazy val fregeReplVersion   = settingKey[String]("Frege REPL version")
+    lazy val fregeRepl          = inputKey[Unit]("Run the Frege REPL")
+    lazy val fregeReplMainClass = settingKey[String]("Frege REPL main class")
+  }
+
+  import autoImport._
+
+  override def trigger = allRequirements
+  override def requires = plugins.JvmPlugin
+  override val projectConfigurations = Seq(fregeReplConfig)
+
+  override def projectSettings = Seq(
     fregeReplVersion := "1.3",
     libraryDependencies += "org.frege-lang" % "frege-repl-core" % fregeReplVersion.value % fregeReplConfig,
     fregeReplMainClass := "frege.repl.FregeRepl",

--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -71,9 +71,16 @@ object SbtFregec extends AutoPlugin {
 
 }
 
+/* Adds integration with frege-repl:
+ *   * Launch the Frege REPL from sbt with the fregeRepl command
+ *   * Access your project's classes and libraries from the Frege REPL
+ * See: https://github.com/Frege/frege-repl
+ */
 object SbtFregeRepl extends AutoPlugin {
 
   object autoImport {
+    // Use a special configuration so as not to pollute the Compile
+    // configuration with frege-repl's jar and transitive dependencies.
     lazy val fregeReplConfig    = config("fregeReplConfig").hide
     lazy val fregeReplVersion   = settingKey[String]("Frege REPL version")
     lazy val fregeRepl          = inputKey[Unit]("Run the Frege REPL")

--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -91,8 +91,10 @@ object SbtFregeRepl extends AutoPlugin {
     libraryDependencies += "org.frege-lang" % "frege-repl-core" % fregeReplVersion.value % fregeReplConfig,
     fregeReplMainClass := "frege.repl.FregeRepl",
     fregeRepl := {
-      val libs: Seq[File] = Classpaths.managedJars(fregeReplConfig, classpathTypes.value, update.value).map(_.data)
-      val cp: String = Path.makeString(libs)
+      val cp: String = Path.makeString((
+        (fullClasspath in Compile).value ++
+        Classpaths.managedJars(fregeReplConfig, classpathTypes.value, update.value)
+      ).map(_.data))
       val forkOptions = new ForkOptions(connectInput = true, outputStrategy = Some(sbt.StdoutOutput))
       val mainClass: String = fregeReplMainClass.value
       new Fork("java", None).fork(forkOptions, Seq("-cp", cp, mainClass)).exitValue()


### PR DESCRIPTION
Fixes #34

This almost works, but something is wrong with the REPL's output stream:

```
> fregeRepl
[info] Running frege.repl.FregeRepl 
Welcome to Frege 3.23.288-gaa3af0c (Oracle Corporation OpenJDK Server VM, 1.8.0_76)

frege> 1

frege> 1 + 1

frege> putStrLn "hello"

frege> :t "hello"
String
```