### PR TITLE
Upgrade default Frege to 3.24

### DIFF
--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -65,7 +65,7 @@ object SbtFrege extends AutoPlugin {
       watchSources.value ++
       ((sourceDirectory in Compile).value / "frege" ** "*").get
     },
-    fregeLibrary := "org.frege-lang" % "frege" % "3.23.401-g7c45277",
+    fregeLibrary := "org.frege-lang" % "frege" % "3.24-7.30",
     libraryDependencies += fregeLibrary.value
   )
 


### PR DESCRIPTION
This would break #35, since frege-repl 1.3 depends on frege 3.23.288.
