### PR TITLE
Enforce UTF8 encoding so that Windows(10?) can build the example

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,5 +2,7 @@ scalaVersion := "2.11.7"
 
 enablePlugins(JettyPlugin)
 
+javacOptions ++= Seq("-encoding", "UTF-8")
+
 libraryDependencies +=
   "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided"


### PR DESCRIPTION
On Windows 10, [without a `-encoding` parameter, `javac` seems to use `Cp1252`](https://docs.oracle.com/javase/6/docs/technotes/tools/windows/javac.html) which doesn't work with the UTF8 characters in the `.java` files that `sbt-frege` generates.

This pull-request explicitly sets the `-encoding` within the provided SBT file to prevent this error.