### PR TITLE
Add support for Test configuration

### DIFF
--- a/src/sbt-test/sbt-frege/with-test/project/plugins.sbt
+++ b/src/sbt-test/sbt-frege/with-test/project/plugins.sbt
@@ -1,0 +1,8 @@
+Option(System.getProperty("plugin.version")) match {
+  case None =>
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Please specify this property using the SBT flag -D.""".stripMargin)
+  case Some(pluginVersion) =>
+    addSbtPlugin("com.earldouglas" % "sbt-frege" % pluginVersion)
+}

--- a/src/sbt-test/sbt-frege/with-test/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
+++ b/src/sbt-test/sbt-frege/with-test/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
@@ -1,0 +1,4 @@
+package com.earldouglas.helloworld.HelloWorld where
+
+main :: [String] -> IO ()
+main _ = print "Hello, world!"

--- a/src/sbt-test/sbt-frege/with-test/src/test/frege/com/earldouglas/helloworld/HelloWorldTest.fr
+++ b/src/sbt-test/sbt-frege/with-test/src/test/frege/com/earldouglas/helloworld/HelloWorldTest.fr
@@ -1,0 +1,6 @@
+package com.earldouglas.helloworld.HelloWorldTest where
+
+import com.earldouglas.helloworld.HelloWorld ()
+
+someTest :: IO ()
+someTest = HelloWorld.main []

--- a/src/sbt-test/sbt-frege/with-test/test
+++ b/src/sbt-test/sbt-frege/with-test/test
@@ -1,0 +1,10 @@
+# check if the file gets created
+$ absent target/frege/com/earldouglas/helloworld/HelloWorld.java
+$ absent target/scala-2.12/classes/com/earldouglas/helloworld/HelloWorld.class
+$ absent target/test-frege/com/earldouglas/helloworld/HelloWorldTest.java
+$ absent target/scala-2.12/test-classes/com/earldouglas/helloworld/HelloWorldTest.class
+> test
+$ exists target/frege/com/earldouglas/helloworld/HelloWorld.java
+$ exists target/scala-2.12/classes/com/earldouglas/helloworld/HelloWorld.class
+$ exists target/test-frege/com/earldouglas/helloworld/HelloWorldTest.java
+$ exists target/scala-2.12/test-classes/com/earldouglas/helloworld/HelloWorldTest.class


### PR DESCRIPTION
Nice to meet you.

This PR adds support for `Test` configuration a.k.a. `src/test/frege`.

- Make `fregeSource` and `fregeTarget` be scoped
- Add `Test` configuration

This changes the target directory structure so that the generated
sources in `Compile` and in `Test` won't get mixed up.

Before:
- target/frege

After:
- target/frege
- target/test-frege

A new scripted test is added, and the existing tests updated accordingly.