### PR TITLE
Update watchSources in scopedSettings

### DIFF
--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -58,7 +58,8 @@ object SbtFregec extends AutoPlugin {
                  (fregeOptions in scope).value)
         }
       cached(((fregeSource in scope).value ** "*.fr").get.toSet).toSeq
-    }.taskValue
+    }.taskValue,
+    watchSources ++= ((fregeSource in scope).value ** "*").get.map(x=>WatchSource(x))
   )
 
   override def projectSettings =
@@ -67,11 +68,6 @@ object SbtFregec extends AutoPlugin {
     Seq(
       fregeOptions := Seq(),
       fregeCompiler := "frege.compiler.Main",
-      watchSources := {
-         watchSources.value ++
-        ((fregeSource in Compile).value ** "*").get.map(x=>WatchSource(x)) ++
-        ((fregeSource in Test   ).value ** "*").get.map(x=>WatchSource(x))
-      },
       fregeLibrary := "org.frege-lang" % "frege" % "3.24.100.1" classifier "jdk8",
       libraryDependencies += fregeLibrary.value
     )


### PR DESCRIPTION
`scopedSettings` sets up the configuration-dependent settings.

This PR modifies the function to update `watchSources` as well so that e.g. `scopedSettings(IntegrationTest)` properly sets up `IntegrationTest / watchSources`.