### PR TITLE
Make "-j" in fregeOption default but optional

### DIFF
--- a/src/main/scala/SbtFrege.scala
+++ b/src/main/scala/SbtFrege.scala
@@ -27,7 +27,6 @@ object SbtFregec extends AutoPlugin {
 
     val fregeArgs = Seq(
       fregeCompiler,
-      "-j",
       "-fp", cps,
       "-d", fregeTarget.getPath,
       "-sp", fregeSource.getPath,
@@ -65,7 +64,7 @@ object SbtFregec extends AutoPlugin {
     scopedSettings(Compile, "frege") ++
     scopedSettings(Test,    "test-frege") ++
     Seq(
-      fregeOptions := Seq(),
+      fregeOptions := Seq("-j"),
       fregeCompiler := "frege.compiler.Main",
       watchSources := {
          watchSources.value ++


### PR DESCRIPTION
`"-j"` supresses compilation of Java files emitted by Fregec.

This prevents Fregec from compiling incrementally, since it appears that Fregec only looks at the modified time of class files which are compiled by Fregec itself.

Obviously, without `"-j"`, Java files will be compiled twice (by Fregec and by Sbt). In large projects, however, having Frege sources incrementally compiled is better considering the short compilation time of Javac.

This PR modifies the invocation of Fregec by changing `"-j"` from a hardcoded argument to the default value of the `fregeOptions` setting. With this, users can remove `"-j"` by `fregeOptions := Seq.empty` if desired.