### PR TITLE
Revert to sbt 1.3.13

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,11 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Run Scala tests
-      run: sbt ^test
-    - name: Run sbt tests
-      run: sbt scripted
+    - run: sbt test
+    - run: sbt scripted

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ name := "sbt-frege"
 
 // build
 sbtPlugin := true
-crossSbtVersions := Seq("1.0.1")
 enablePlugins(SbtPlugin)
 scalaVersion := "2.12.12"
 scalacOptions ++= Seq( "-deprecation"

--- a/src/sbt-test/sbt-frege/sbt-1.4.3/project/build.properties
+++ b/src/sbt-test/sbt-frege/sbt-1.4.3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.3

--- a/src/sbt-test/sbt-frege/sbt-1.4.3/project/plugins.sbt
+++ b/src/sbt-test/sbt-frege/sbt-1.4.3/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.earldouglas" % "sbt-frege" % "0.1.0-SNAPSHOT")

--- a/src/sbt-test/sbt-frege/sbt-1.4.3/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
+++ b/src/sbt-test/sbt-frege/sbt-1.4.3/src/main/frege/com/earldouglas/helloworld/HelloWorld.fr
@@ -1,0 +1,4 @@
+package com.earldouglas.helloworld.HelloWorld where
+
+main :: [String] -> IO ()
+main _ = print "Hello, world!"

--- a/src/sbt-test/sbt-frege/sbt-1.4.3/test
+++ b/src/sbt-test/sbt-frege/sbt-1.4.3/test
@@ -1,0 +1,6 @@
+# check if the file gets created
+$ absent target/frege/com/earldouglas/helloworld/HelloWorld.java
+$ absent target/scala-2.12/classes/com/earldouglas/helloworld/HelloWorld.class
+> compile
+$ exists target/frege/com/earldouglas/helloworld/HelloWorld.java
+$ exists target/scala-2.12/classes/com/earldouglas/helloworld/HelloWorld.class


### PR DESCRIPTION
A change in sbt 1.4 prevents scripted from running tests using older
versions of sbt:

```
[info] [error] Expected ID character
[info] [error] reload usage:
[info] [error]   reload   (Re)loads the current project or changes to plugins project or returns from it.
[info] [error]
[info] [error] Expected whitespace character
[info] [error] Expected project ID
[info] [error] Expected configuration
[info] [error] Expected ':' (if selecting a configuration)
[info] [error] Expected key
[info] [error] Not a valid key: reload (similar: onUnload, onLoad, testLoader)
[info] [error] reload;initialize
```

This change reverts the project sbt version to 1.3.13, and adds a
scripted test for sbt 1.4.3 in addition to the scripted test for sbt
1.0.1 (the minimum supported version).