### PR TITLE
Drop unused sbt configuration

### DIFF
--- a/src/reqs/build.sbt
+++ b/src/reqs/build.sbt
@@ -1,1 +1,0 @@
-scalaVersion := "2.4.0"

--- a/src/reqs/project/build.properties
+++ b/src/reqs/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.0.1


### PR DESCRIPTION
These are automatically created/overwritten by *src/reqs/check.sh*, so
we don't need to keep them.
