### PR TITLE
scala-library: 2.12.18 -> 2.12.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "sbt-frege"
 // build
 sbtPlugin := true
 enablePlugins(SbtPlugin)
-scalaVersion := "2.12.18"
+scalaVersion := "2.12.19"
 scalacOptions ++= Seq( "-deprecation"
                      , "-encoding", "utf8"
                      , "-feature"


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.12.18` to `2.12.19`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.12.19) - [Version Diff](https://github.com/scala/scala/compare/v2.12.18...v2.12.19)