### PR TITLE
scala-library: 2.12.19 -> 2.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "sbt-frege"
 // build
 sbtPlugin := true
 enablePlugins(SbtPlugin)
-scalaVersion := "2.12.19"
+scalaVersion := "2.13.13"
 scalacOptions ++= Seq( "-deprecation"
                      , "-encoding", "utf8"
                      , "-feature"


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.12.19` to `2.13.13`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.13.13) - [Version Diff](https://github.com/scala/scala/compare/v2.12.19...v2.13.13)